### PR TITLE
Refactor array fields with chip-based UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,7 @@ setupSnowForm({
     label: 'text-sm font-medium',   // Applied to labels
     description: 'text-xs text-gray-500', // Applied to descriptions
     errorMessage: 'text-xs text-red-500', // Applied to error messages
-    button: 'px-2 py-1 text-sm border rounded', // Applied to array +/× buttons
-    arrayContainer: 'flex flex-col gap-2', // Applied to array field container
-    arrayItem: 'flex items-center gap-2',  // Applied to each array item row
+    chip: 'inline-flex items-center gap-1 px-2 py-1 text-sm bg-blue-100 text-blue-800 rounded-full mr-1 mt-1', // Applied to array chips
   },
 });
 ```
@@ -380,7 +378,11 @@ setupSnowForm({
 
 > **Note**: For complex array UIs, we recommend using a custom `render` function instead. The built-in array support is a convenience fallback for simple cases.
 
-SnowForm has basic support for array fields using `z.array()`. The element type determines which component is used for each item:
+SnowForm supports array fields using `z.array()` with a chip-based UI:
+
+- **String/Number arrays**: Type in the input, press Enter to add a chip
+- **Enum arrays**: Select from dropdown to add a chip (selected options are removed from dropdown)
+- Each chip has a × button to remove it
 
 ```tsx
 const schema = z.object({
@@ -391,16 +393,18 @@ const schema = z.object({
 <SnowForm
   schema={schema}
   overrides={{
-    tags: { label: 'Tags', placeholder: 'Enter a tag' },
-    interests: { label: 'Interests' },
+    tags: { label: 'Tags', placeholder: 'Enter a tag and press Enter' },
+    interests: {
+      label: 'Interests',
+      options: [
+        { value: 'tech', label: 'Technology' },
+        { value: 'design', label: 'Design' },
+        { value: 'business', label: 'Business' },
+      ],
+    },
   }}
 />
 ```
-
-Each array field renders with + and × buttons to add/remove items. Styles can be customized via `setupSnowForm`:
-- `styles.arrayContainer` - Container wrapping all array items
-- `styles.arrayItem` - Each item row (input + remove button)
-- `styles.button` - The +/× buttons
 
 ## Children Pattern
 

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -25,9 +25,7 @@ setupSnowForm({
   styles: {
     form: 'space-y-4',
     formItem: 'space-y-1',
-    button: 'px-2 py-1 text-sm border border-gray-300 rounded hover:bg-gray-100',
-    arrayContainer: 'flex flex-col gap-2',
-    arrayItem: 'flex items-center gap-2',
+    chip: 'inline-flex items-center gap-1 px-2 py-1 text-sm bg-blue-100 text-blue-800 rounded-full mr-1 mt-1',
   },
   onError: (formRef, errors) => {
     const firstErrorField = Object.keys(errors)[0];
@@ -190,12 +188,18 @@ export function App() {
         // Array fields
         tags: {
           label: 'Tags',
-          description: 'Add tags for your profile',
+          description: 'Press Enter to add a tag',
           placeholder: 'Enter a tag',
         },
         interests: {
           label: 'Interests',
           description: 'Select your areas of interest',
+          options: [
+            { value: 'tech', label: 'Technology' },
+            { value: 'design', label: 'Design' },
+            { value: 'business', label: 'Business' },
+            { value: 'marketing', label: 'Marketing' },
+          ],
         },
         acceptTerms: {
           hideLabel: true,

--- a/src/__tests__/SnowFormField.test.tsx
+++ b/src/__tests__/SnowFormField.test.tsx
@@ -481,7 +481,7 @@ describe('SnowFormField', () => {
   // ===========================================================================
 
   describe('Array Fields', () => {
-    it('should render array field with add button', () => {
+    it('should render array field with input', () => {
       renderSnowFormField({
         fieldInfo: {
           baseType: 'array',
@@ -492,10 +492,10 @@ describe('SnowFormField', () => {
         defaultValue: [],
       });
 
-      expect(screen.getByRole('button', { name: /add item/i })).toBeInTheDocument();
+      expect(screen.getByRole('textbox')).toBeInTheDocument();
     });
 
-    it('should render array items with inputs and remove buttons', () => {
+    it('should render chips with remove buttons for existing items', () => {
       renderSnowFormField({
         fieldInfo: {
           baseType: 'array',
@@ -506,14 +506,17 @@ describe('SnowFormField', () => {
         defaultValue: ['tag1', 'tag2'],
       });
 
-      const inputs = screen.getAllByRole('textbox');
-      expect(inputs).toHaveLength(2);
+      // Only one input for adding new items
+      expect(screen.getAllByRole('textbox')).toHaveLength(1);
 
-      const removeButtons = screen.getAllByRole('button', { name: /remove item/i });
-      expect(removeButtons).toHaveLength(2);
+      // Chips are clickable buttons with the value
+      const chip1 = screen.getByRole('button', { name: /remove tag1/i });
+      const chip2 = screen.getByRole('button', { name: /remove tag2/i });
+      expect(chip1).toBeInTheDocument();
+      expect(chip2).toBeInTheDocument();
     });
 
-    it('should add new item when clicking add button', async () => {
+    it('should add new item when pressing Enter', async () => {
       const user = userEvent.setup();
       let capturedValue: unknown;
 
@@ -546,10 +549,10 @@ describe('SnowFormField', () => {
 
       render(<CaptureForm />);
 
-      const addButton = screen.getByRole('button', { name: /add item/i });
-      await user.click(addButton);
+      const input = screen.getByRole('textbox');
+      await user.type(input, 'new item{Enter}');
 
-      expect(capturedValue).toEqual(['existing', '']);
+      expect(capturedValue).toEqual(['existing', 'new item']);
     });
 
     it('should remove item when clicking remove button', async () => {
@@ -585,13 +588,13 @@ describe('SnowFormField', () => {
 
       render(<CaptureForm />);
 
-      const removeButtons = screen.getAllByRole('button', { name: /remove item/i });
-      await user.click(removeButtons[0]);
+      const chip = screen.getByRole('button', { name: /remove first/i });
+      await user.click(chip);
 
       expect(capturedValue).toEqual(['second']);
     });
 
-    it('should render array of numbers with number inputs', () => {
+    it('should render array of numbers with number input and chips', () => {
       renderSnowFormField({
         fieldInfo: {
           baseType: 'array',
@@ -602,8 +605,13 @@ describe('SnowFormField', () => {
         defaultValue: [1, 2, 3],
       });
 
-      const inputs = screen.getAllByRole('spinbutton');
-      expect(inputs).toHaveLength(3);
+      // Only one number input for adding new items
+      expect(screen.getAllByRole('spinbutton')).toHaveLength(1);
+
+      // Chips are clickable buttons
+      expect(screen.getByRole('button', { name: /remove 1/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /remove 2/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /remove 3/i })).toBeInTheDocument();
     });
 
     it('should render array of enums with select inputs', () => {

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -34,9 +34,7 @@ import {
   getLabelClass,
   getDescriptionClass,
   getErrorMessageClass,
-  getButtonClass,
-  getArrayContainerClass,
-  getArrayItemClass,
+  getChipClass,
   resetStylesRegistry,
   type FormStyles,
 } from './stylesRegistry';
@@ -334,9 +332,7 @@ export {
   getLabelClass,
   getDescriptionClass,
   getErrorMessageClass,
-  getButtonClass,
-  getArrayContainerClass,
-  getArrayItemClass,
+  getChipClass,
   resetStylesRegistry,
   type FormStyles,
 };

--- a/src/registry/stylesRegistry.ts
+++ b/src/registry/stylesRegistry.ts
@@ -16,12 +16,8 @@ export interface FormStyles {
   description?: string;
   /** CSS class for error messages (e.g., 'text-xs text-red-500') */
   errorMessage?: string;
-  /** CSS class for buttons (e.g., array add/remove buttons) */
-  button?: string;
-  /** CSS class for array field container (e.g., 'flex flex-col gap-2') */
-  arrayContainer?: string;
-  /** CSS class for each array item row (e.g., 'flex items-center gap-2') */
-  arrayItem?: string;
+  /** CSS class for chips container (e.g., 'flex flex-wrap gap-1') */
+  chip?: string;
 }
 
 let registeredStyles: FormStyles = {};
@@ -83,27 +79,11 @@ export function getErrorMessageClass(): string | undefined {
 }
 
 /**
- * Get the registered button class
+ * Get the registered chip class
  * @internal Used by ArrayFieldRenderer
  */
-export function getButtonClass(): string | undefined {
-  return registeredStyles.button;
-}
-
-/**
- * Get the registered array container class
- * @internal Used by ArrayFieldRenderer
- */
-export function getArrayContainerClass(): string | undefined {
-  return registeredStyles.arrayContainer;
-}
-
-/**
- * Get the registered array item class
- * @internal Used by ArrayFieldRenderer
- */
-export function getArrayItemClass(): string | undefined {
-  return registeredStyles.arrayItem;
+export function getChipClass(): string | undefined {
+  return registeredStyles.chip;
 }
 
 /**


### PR DESCRIPTION
## Summary

Replace the input-per-item approach for array fields with a modern chip-based UI. String/number arrays now use a text input with Enter to add, enum arrays use dropdown with dynamic filtering of selected items. Chips are fully clickable buttons for removal instead of separate × buttons.

## Changes

- ArrayFieldRenderer: One input/select + clickable chips (instead of inputs + buttons per item)
- stylesRegistry: Single `chip` class replaces 3 classes (arrayContainer, arrayItem, button)
- Tests updated to match new chip-based interactions
- Demo and README updated with examples and styling

## Testing

- All 166 tests pass
- Build succeeds without errors
- Manual testing in demo with string, number, and enum arrays

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Nouvelles Fonctionnalités**
  * Interface révisée pour les champs de tableau : passage d'une approche basée sur des boutons (+/×) à une interface basée sur des puces. Les utilisateurs peuvent désormais ajouter des éléments via saisie de texte et appui sur Entrée ou sélection dans une liste déroulante pour les énumérations, avec suppression directe via des puces.

* **Documentation**
  * Mise à jour des exemples et guides pour refléter la nouvelle interaction basée sur les puces et l'ajout d'éléments par saisie clavier.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->