### PR TITLE
Allow custom type overrides to bypass ArrayFieldRenderer

### DIFF
--- a/src/SnowFormField.tsx
+++ b/src/SnowFormField.tsx
@@ -87,8 +87,8 @@ export function SnowFormField<
     );
   }
 
-  // Array fields
-  if (fieldInfo.baseType === 'array' && fieldInfo.arrayElementInfo) {
+  // Array fields (only use ArrayFieldRenderer if no custom type override)
+  if (fieldInfo.baseType === 'array' && fieldInfo.arrayElementInfo && !override?.type) {
     return (
       <ArrayFieldRenderer
         name={name}


### PR DESCRIPTION
## Summary

Allows fields with z.array() type to use custom registered components (like 'media-library') instead of always rendering with ArrayFieldRenderer. When an override specifies a custom type, that component is used instead.

## Test plan

- All 167 tests pass, including new test verifying custom type override on array fields
- Existing array fields without type override continue to use ArrayFieldRenderer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Les champs tableau supportent désormais les remplacements de type personnalisés, permettant l'utilisation de composants personnalisés au lieu du rendu par défaut.

* **Tests**
  * Ajout de tests vérifiant que les remplacements de type personnalisés fonctionnent correctement avec des composants personnalisés et les paramètres de configuration associés.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->