### PR TITLE
fix: update code generator to use valid FormStyles keys

### DIFF
--- a/demo/src/components/codeGenerator.ts
+++ b/demo/src/components/codeGenerator.ts
@@ -61,9 +61,7 @@ setupSnowForm({
   styles: {
     form: 'space-y-4',
     formItem: 'space-y-1',
-    button: 'px-2 py-1 text-sm border border-gray-300 rounded',
-    arrayContainer: 'flex flex-col gap-2',
-    arrayItem: 'flex items-center gap-2',
+    chip: 'inline-flex items-center gap-1 px-2 py-1 text-sm bg-blue-100 text-blue-800 rounded-full mr-1 mt-1',
   },
 });`;
 }


### PR DESCRIPTION
## Summary
Remove outdated invalid style keys (button, arrayContainer, arrayItem) from the demo code generator and replace with the correct chip style that matches the current FormStyles interface.

## Changes
- Updated setupSnowForm styles example in code generator to use valid FormStyles keys
- Replaced non-existent keys with chip style definition

🤖 Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de sortie

* **Style**
  * Mise à jour des styles de formulaire : suppression de certains styles de composants et ajout de nouveaux styles visuels pour améliorer l'apparence de l'interface utilisateur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->