### PR TITLE
Rename package to @snowpact/snowform

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-# CLAUDE.md - @snowpact/react-rhf-zod-form
+# CLAUDE.md - @snowpact/snowform
 
 Automatic form generation from Zod schemas with react-hook-form.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
-# @snowpact/react-rhf-zod-form
+# @snowpact/snowform
+
+> Previously published as `@snowpact/react-rhf-zod-form` (now deprecated). Migration: replace the package name in imports and `package.json`, nothing else changed.
 
 Automatic form generation from Zod schemas with react-hook-form.
 
-**[Live Demo](https://snowpact.github.io/react-rhf-zod-form/)**
+**[Live Demo](https://snowpact.github.io/snowform/)**
 
 ## Requirements
 
@@ -24,7 +26,7 @@ Automatic form generation from Zod schemas with react-hook-form.
 ## Installation
 
 ```bash
-npm install @snowpact/react-rhf-zod-form
+npm install @snowpact/snowform
 ```
 
 ### Peer Dependencies
@@ -40,8 +42,8 @@ npm install react-hook-form zod @hookform/resolvers
 Register your components once at app startup (e.g., `app/setup.ts`, `_app.tsx`, or `main.tsx`).
 
 ```tsx
-import { setupSnowForm } from '@snowpact/react-rhf-zod-form';
-import type { RegisteredComponentProps, FormUILabelProps } from '@snowpact/react-rhf-zod-form';
+import { setupSnowForm } from '@snowpact/snowform';
+import type { RegisteredComponentProps, FormUILabelProps } from '@snowpact/snowform';
 
 // Example custom input component
 function MyInput({ value, onChange, placeholder, disabled, className, name }: RegisteredComponentProps<string>) {
@@ -107,7 +109,7 @@ setupSnowForm({
 ### 2. Use SnowForm
 
 ```tsx
-import { SnowForm } from '@snowpact/react-rhf-zod-form';
+import { SnowForm } from '@snowpact/snowform';
 import { z } from 'zod';
 
 const schema = z.object({
@@ -172,7 +174,7 @@ function MyForm() {
 ### With i18next
 
 ```tsx
-import { setupSnowForm } from '@snowpact/react-rhf-zod-form';
+import { setupSnowForm } from '@snowpact/snowform';
 import i18next from 'i18next';
 
 setupSnowForm({
@@ -184,7 +186,7 @@ setupSnowForm({
 ### With next-intl
 
 ```tsx
-import { setupSnowForm } from '@snowpact/react-rhf-zod-form';
+import { setupSnowForm } from '@snowpact/snowform';
 import { useTranslations } from 'next-intl';
 
 // In a client component
@@ -486,7 +488,7 @@ import type {
   FormUILabelProps,
   FormUIDescriptionProps,
   FormUIErrorMessageProps,
-} from '@snowpact/react-rhf-zod-form';
+} from '@snowpact/snowform';
 ```
 
 ## License

--- a/demo/index.html
+++ b/demo/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>@snowpact/react-rhf-zod-form Demo</title>
+    <title>@snowpact/snowform Demo</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <style>
       /* Code syntax highlighting */

--- a/demo/src/App.tsx
+++ b/demo/src/App.tsx
@@ -258,7 +258,7 @@ export function App() {
       {/* Main Content */}
       <div className="flex-1 bg-gray-50 p-8 overflow-y-auto">
         <div className="max-w-2xl mx-auto">
-          <h1 className="text-3xl font-bold text-gray-900 mb-2">@snowpact/react-rhf-zod-form</h1>
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">@snowpact/snowform</h1>
           <p className="text-gray-600 mb-8">
             Automatic form generation from Zod schemas with react-hook-form
           </p>

--- a/demo/src/components/codeGenerator.ts
+++ b/demo/src/components/codeGenerator.ts
@@ -2,13 +2,13 @@ import type { DemoConfig } from './types';
 
 export function generateInstallCode(): string {
   return `npm install react-hook-form @hookform/resolvers zod
-npm install @snowpact/react-rhf-zod-form`;
+npm install @snowpact/snowform`;
 }
 
 export function generateSetupCode(): string {
   return `// Run once at app startup (e.g., app/setup.ts, _app.tsx, main.tsx)
-import { setupSnowForm } from '@snowpact/react-rhf-zod-form';
-import type { RegisteredComponentProps } from '@snowpact/react-rhf-zod-form';
+import { setupSnowForm } from '@snowpact/snowform';
+import type { RegisteredComponentProps } from '@snowpact/snowform';
 
 // Your input component
 function MyInput({ value, onChange, placeholder, disabled, name }: RegisteredComponentProps<string>) {
@@ -70,7 +70,7 @@ export function generateFormCode(config: DemoConfig): string {
   const debugProp = config.showDebugMode ? '\n      debug={true}' : '';
 
   if (config.renderMode === 'children') {
-    return `import { SnowForm } from '@snowpact/react-rhf-zod-form';
+    return `import { SnowForm } from '@snowpact/snowform';
 import { z } from 'zod';
 
 const schema = z.object({
@@ -123,7 +123,7 @@ function MyForm() {
 }`;
   }
 
-  return `import { SnowForm } from '@snowpact/react-rhf-zod-form';
+  return `import { SnowForm } from '@snowpact/snowform';
 import { z } from 'zod';
 
 const schema = z.object({

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -5,14 +5,14 @@ import { resolve } from 'path';
 export default defineConfig({
   plugins: [react()],
   root: resolve(__dirname),
-  base: '/react-rhf-zod-form/',
+  base: '/snowform/',
   build: {
     outDir: resolve(__dirname, '../demo-dist'),
     emptyOutDir: true,
   },
   resolve: {
     alias: {
-      '@snowpact/react-rhf-zod-form': resolve(__dirname, '../src'),
+      '@snowpact/snowform': resolve(__dirname, '../src'),
     },
   },
 });

--- a/examples/full-setup.md
+++ b/examples/full-setup.md
@@ -23,8 +23,8 @@ import { toast } from 'sonner';
 import {
   setupSnowForm,
   normalizeDateToISO,
-} from '@snowpact/react-rhf-zod-form';
-import type { RegisteredComponentProps, SubmitButtonProps } from '@snowpact/react-rhf-zod-form';
+} from '@snowpact/snowform';
+import type { RegisteredComponentProps, SubmitButtonProps } from '@snowpact/snowform';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snowpact/snowform",
-  "version": "1.5.3",
+  "version": "1.5.4",
   "description": "Automatic form generation from Zod schemas with react-hook-form",
   "author": "Snowpact",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,15 @@
 {
-  "name": "@snowpact/react-rhf-zod-form",
+  "name": "@snowpact/snowform",
   "version": "1.5.3",
   "description": "Automatic form generation from Zod schemas with react-hook-form",
   "author": "Snowpact",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/snowpact/react-rhf-zod-form"
+    "url": "https://github.com/snowpact/snowform"
   },
   "keywords": [
+    "snowform",
     "react",
     "form",
     "zod",

--- a/src/registry/componentRegistry.tsx
+++ b/src/registry/componentRegistry.tsx
@@ -43,7 +43,7 @@ let formUIComponents: FormUIComponents = {};
  *
  * @example
  * ```typescript
- * import { registerComponent } from '@snowpact/react-rhf-zod-form';
+ * import { registerComponent } from '@snowpact/snowform';
  * import { MyCustomInput } from './MyCustomInput';
  *
  * registerComponent('text', MyCustomInput);
@@ -60,7 +60,7 @@ export function registerComponent<TValue = unknown>(type: FieldType, component: 
  *
  * @example
  * ```typescript
- * import { registerComponents } from '@snowpact/react-rhf-zod-form';
+ * import { registerComponents } from '@snowpact/snowform';
  *
  * registerComponents({
  *   text: MyInput,

--- a/src/registry/index.ts
+++ b/src/registry/index.ts
@@ -196,7 +196,7 @@ let isSetup = false;
  *
  * @example Basic setup
  * ```typescript
- * import { setupSnowForm } from '@snowpact/react-rhf-zod-form';
+ * import { setupSnowForm } from '@snowpact/snowform';
  *
  * setupSnowForm({
  *   translate: (key) => key, // Identity function if no i18n
@@ -205,7 +205,7 @@ let isSetup = false;
  *
  * @example With i18next
  * ```typescript
- * import { setupSnowForm } from '@snowpact/react-rhf-zod-form';
+ * import { setupSnowForm } from '@snowpact/snowform';
  * import i18next from 'i18next';
  *
  * setupSnowForm({
@@ -215,7 +215,7 @@ let isSetup = false;
  *
  * @example Full configuration
  * ```typescript
- * import { setupSnowForm } from '@snowpact/react-rhf-zod-form';
+ * import { setupSnowForm } from '@snowpact/snowform';
  * import { MyInput, MySelect, MyButton } from './components';
  *
  * setupSnowForm({


### PR DESCRIPTION
## Summary

- Rename npm package from `@snowpact/react-rhf-zod-form` to `@snowpact/snowform` for better discoverability
- Update all imports, docs, demo, and GitHub Pages references
- No code changes — same API surface, same version (1.5.3)

## After merge

```bash
npm publish --access public

npm deprecate '@snowpact/react-rhf-zod-form@*' \
  "Package renamed to @snowpact/snowform. Migration: npm install @snowpact/snowform and update imports. No code changes required."
```

## Test plan

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm test` — 167/167 passed
- [x] `pnpm build` — OK
- [x] Grep for old name — only the migration note in README remains (intentional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
  * Les chemins d'importation et les exemples de code ont été mis à jour dans l'ensemble de la documentation pour refléter la nouvelle identité du paquet.

## Chores
  * Le paquet a été renommé de `@snowpact/react-rhf-zod-form` à `@snowpact/snowform`.
  * Version mise à jour vers 1.5.4.
  * Configuration du projet et de la démonstration mise à jour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->