### PR TITLE
feat: support Zod 4 schemas alongside Zod 3

### DIFF
--- a/src/SnowForm.tsx
+++ b/src/SnowForm.tsx
@@ -1,6 +1,12 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
-import { useForm, type DefaultValues, type FieldErrors, type Path, type UseFormReturn } from 'react-hook-form';
-import type { z } from 'zod';
+import {
+  useForm,
+  type DefaultValues,
+  type FieldErrors,
+  type FieldValues,
+  type Path,
+  type UseFormReturn,
+} from 'react-hook-form';
 
 import { SnowFormField } from './SnowFormField';
 import { Form, FormField } from './FormProvider';
@@ -8,7 +14,7 @@ import { executeOnErrorBehavior } from './registry/behaviorRegistry';
 import { getRegisteredSubmitButton } from './registry/componentRegistry';
 import { getFormClass } from './registry/stylesRegistry';
 import { getT } from './registry/translationRegistry';
-import type { SchemaFieldInfo, SnowFormHelpers, SnowFormProps, ZodObjectOrEffects } from './types';
+import type { InferZodValues, SchemaFieldInfo, SnowFormHelpers, SnowFormProps, ZodObjectOrEffects } from './types';
 import {
   applyEmptyValueOverrides,
   cn,
@@ -60,7 +66,11 @@ import {
  * </SnowForm>
  * ```
  */
-export function SnowForm<TSchema extends ZodObjectOrEffects, TResponse = unknown>({
+export function SnowForm<
+  TSchema extends ZodObjectOrEffects,
+  TResponse = unknown,
+  TValues extends FieldValues = InferZodValues<TSchema>,
+>({
   schema,
   overrides = {},
   defaultValues: providedDefaultValues,
@@ -72,8 +82,8 @@ export function SnowForm<TSchema extends ZodObjectOrEffects, TResponse = unknown
   className,
   id,
   children,
-}: SnowFormProps<TSchema, TResponse>): React.ReactElement {
-  type FormValues = z.infer<TSchema>;
+}: SnowFormProps<TSchema, TResponse, TValues>): React.ReactElement {
+  type FormValues = TValues;
 
   const t = getT();
   const formRef = useRef<HTMLFormElement>(null);
@@ -111,7 +121,7 @@ export function SnowForm<TSchema extends ZodObjectOrEffects, TResponse = unknown
   );
 
   const form = useForm<FormValues>({
-    resolver: createZodResolver(schema),
+    resolver: createZodResolver<FormValues>(schema),
     defaultValues: computedDefaultValues,
   });
 

--- a/src/__tests__/form-perf.bench.tsx
+++ b/src/__tests__/form-perf.bench.tsx
@@ -1,0 +1,169 @@
+import { cleanup, fireEvent, render } from '@testing-library/react';
+import { beforeAll, bench, describe } from 'vitest';
+import { z } from 'zod';
+import * as z4 from 'zod/v4';
+
+import { SnowForm } from '../SnowForm';
+import { resetSnowForm, setupSnowForm } from '../registry';
+import type { RegisteredComponentProps } from '../types';
+import { getZodFieldInfo, getZodShape } from '../utils';
+
+// =============================================================================
+// Form perf — Zod 3 (ancien) vs Zod 4 (nouveau), small vs large form, with
+// interactions. Run: pnpm exec vitest bench src/__tests__/form-perf.bench.tsx
+//
+//   mount          — initial render of <SnowForm>
+//   introspection  — snowform's per-render work (getZodShape + getZodFieldInfo)
+//   validation     — schema.safeParse (fires on submit / on each edit after submit)
+//   interaction    — render + type a field + submit (full React+RHF+zod roundtrip)
+// =============================================================================
+
+const KINDS = ['string', 'email', 'number', 'boolean', 'enum', 'date'] as const;
+type Kind = (typeof KINDS)[number];
+
+function buildSet(n: number) {
+  const fields = Array.from({ length: n }, (_, i) => ({ name: `field${i}`, kind: KINDS[i % KINDS.length] as Kind }));
+  const mkShape = (f: (k: Kind) => unknown): Record<string, unknown> => {
+    const shape: Record<string, unknown> = {};
+    for (const fl of fields) shape[fl.name] = f(fl.kind);
+    return shape;
+  };
+  const v3 = z.object(
+    mkShape(k =>
+      k === 'string'
+        ? z.string()
+        : k === 'email'
+          ? z.string().email()
+          : k === 'number'
+            ? z.number()
+            : k === 'boolean'
+              ? z.boolean()
+              : k === 'enum'
+                ? z.enum(['a', 'b', 'c'])
+                : z.date()
+    ) as z.ZodRawShape
+  );
+  const v4 = z4.object(
+    mkShape(k =>
+      k === 'string'
+        ? z4.string()
+        : k === 'email'
+          ? z4.string().email()
+          : k === 'number'
+            ? z4.number()
+            : k === 'boolean'
+              ? z4.boolean()
+              : k === 'enum'
+                ? z4.enum(['a', 'b', 'c'])
+                : z4.date()
+    ) as z4.ZodRawShape
+  );
+  const data: Record<string, unknown> = {};
+  for (const fl of fields) {
+    data[fl.name] =
+      fl.kind === 'number'
+        ? 42
+        : fl.kind === 'boolean'
+          ? true
+          : fl.kind === 'enum'
+            ? 'a'
+            : fl.kind === 'date'
+              ? new Date('2024-01-01')
+              : fl.kind === 'email'
+                ? 'user@example.com'
+                : 'hello';
+  }
+  return { v3, v4, data };
+}
+
+const SMALL = buildSet(5);
+const LARGE = buildSet(40);
+
+// Minimal components so <SnowForm> can mount every field type.
+const Input = ({ value, onChange, name }: RegisteredComponentProps<string>) => (
+  <input data-testid={name} value={value ?? ''} onChange={e => onChange(e.target.value)} />
+);
+const NumberInput = ({ value, onChange, name }: RegisteredComponentProps<number>) => (
+  <input type="number" data-testid={name} value={value ?? ''} onChange={e => onChange(Number(e.target.value))} />
+);
+const Checkbox = ({ value, onChange, name }: RegisteredComponentProps<boolean>) => (
+  <input type="checkbox" data-testid={name} checked={value ?? false} onChange={e => onChange(e.target.checked)} />
+);
+const Select = ({ value, onChange, name, options }: RegisteredComponentProps<string>) => (
+  <select data-testid={name} value={value ?? ''} onChange={e => onChange(e.target.value)}>
+    {options?.map(o => (
+      <option key={o.value} value={o.value}>
+        {o.label}
+      </option>
+    ))}
+  </select>
+);
+
+beforeAll(() => {
+  resetSnowForm();
+  setupSnowForm({
+    translate: (k: string) => k,
+    components: { text: Input, email: Input, number: NumberInput, checkbox: Checkbox, select: Select, date: Input },
+    submitButton: ({ children }) => <button type="submit">{children ?? 'submit'}</button>,
+  });
+});
+
+// One realistic interaction: render, type into the first field, submit (validates
+// every field), let the async validation settle.
+async function fillAndSubmit(schema: z.ZodTypeAny) {
+  const { container } = render(<SnowForm schema={schema as never} onSubmit={async () => {}} />);
+  const first = container.querySelector('[data-testid="field0"]');
+  if (first) fireEvent.change(first, { target: { value: 'hello' } });
+  const form = container.querySelector('form');
+  if (form) fireEvent.submit(form);
+  await new Promise(r => setTimeout(r, 0));
+  cleanup();
+}
+
+describe('mount · small (5)', () => {
+  bench('zod 3', () => void (render(<SnowForm schema={SMALL.v3} />), cleanup()));
+  bench('zod 4', () => void (render(<SnowForm schema={SMALL.v4} />), cleanup()));
+});
+describe('mount · large (40)', () => {
+  bench('zod 3', () => void (render(<SnowForm schema={LARGE.v3} />), cleanup()));
+  bench('zod 4', () => void (render(<SnowForm schema={LARGE.v4} />), cleanup()));
+});
+
+describe('introspection · small (5)', () => {
+  bench('zod 3', () => {
+    const s = getZodShape(SMALL.v3);
+    for (const f of Object.values(s)) getZodFieldInfo(f);
+  });
+  bench('zod 4', () => {
+    const s = getZodShape(SMALL.v4);
+    for (const f of Object.values(s)) getZodFieldInfo(f);
+  });
+});
+describe('introspection · large (40)', () => {
+  bench('zod 3', () => {
+    const s = getZodShape(LARGE.v3);
+    for (const f of Object.values(s)) getZodFieldInfo(f);
+  });
+  bench('zod 4', () => {
+    const s = getZodShape(LARGE.v4);
+    for (const f of Object.values(s)) getZodFieldInfo(f);
+  });
+});
+
+describe('validation safeParse · small (5)', () => {
+  bench('zod 3', () => void SMALL.v3.safeParse(SMALL.data));
+  bench('zod 4', () => void SMALL.v4.safeParse(SMALL.data));
+});
+describe('validation safeParse · large (40)', () => {
+  bench('zod 3', () => void LARGE.v3.safeParse(LARGE.data));
+  bench('zod 4', () => void LARGE.v4.safeParse(LARGE.data));
+});
+
+describe('interaction: type + submit · small (5)', () => {
+  bench('zod 3', async () => await fillAndSubmit(SMALL.v3));
+  bench('zod 4', async () => await fillAndSubmit(SMALL.v4 as never));
+});
+describe('interaction: type + submit · large (40)', () => {
+  bench('zod 3', async () => await fillAndSubmit(LARGE.v3));
+  bench('zod 4', async () => await fillAndSubmit(LARGE.v4 as never));
+});

--- a/src/__tests__/types-v4.test-d.tsx
+++ b/src/__tests__/types-v4.test-d.tsx
@@ -1,0 +1,67 @@
+import { z } from 'zod';
+import * as z4 from 'zod/v4';
+
+import { SnowForm } from '../SnowForm';
+import type { SnowFormProps } from '../types';
+
+// =============================================================================
+// Type-level tests: <SnowForm> must accept Zod 3 AND Zod 4 object schemas and
+// infer the values type correctly for both. Verified by `tsc --noEmit` (this
+// file has no runtime cases; `vitest run` ignores *.test-d.tsx).
+// =============================================================================
+
+// --- Zod 3 (must keep working) ---
+const v3 = z.object({ name: z.string(), age: z.number() });
+const _p3: SnowFormProps<typeof v3> = {
+  schema: v3,
+  defaultValues: { name: 'a' },
+  onSubmit: async values => {
+    const n: string = values.name;
+    const a: number = values.age;
+    void n;
+    void a;
+  },
+};
+void _p3;
+
+// --- Zod 4 via SnowFormProps ---
+const v4 = z4.object({ name: z4.string(), age: z4.number() });
+const _p4: SnowFormProps<typeof v4> = {
+  schema: v4,
+  defaultValues: { name: 'a' },
+  onSubmit: async values => {
+    const n: string = values.name;
+    const a: number = values.age;
+    // @ts-expect-error proves `values` is precisely typed (not `any`): age is a number
+    const notString: string = values.age;
+    // @ts-expect-error proves unknown keys are rejected
+    void values.doesNotExist;
+    void n;
+    void a;
+    void notString;
+  },
+};
+void _p4;
+
+// --- Zod 4 through the actual <SnowForm> component (real consumer usage) ---
+const _el4 = (
+  <SnowForm
+    schema={v4}
+    onSubmit={async values => {
+      const n: string = values.name;
+      void n;
+    }}
+  />
+);
+void _el4;
+
+// --- Zod 4 refined object still accepted, values still inferred ---
+const v4refined = z4.object({ pwd: z4.string(), confirm: z4.string() }).refine(d => d.pwd === d.confirm);
+const _pref: SnowFormProps<typeof v4refined> = {
+  schema: v4refined,
+  onSubmit: async values => {
+    const p: string = values.pwd;
+    void p;
+  },
+};
+void _pref;

--- a/src/__tests__/zod-v4.test.ts
+++ b/src/__tests__/zod-v4.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import * as z4 from 'zod/v4';
+
+import { getZodFieldInfo, getZodShape } from '../utils';
+
+// =============================================================================
+// Zod 4 introspection — mirrors the Zod 3 contract in utils.test.ts but against
+// schemas built with the `zod/v4` subpath (shipped by zod 3.25). The internal
+// shape changed entirely in v4 (`_zod.def` instead of `_def`, ZodEffects removed,
+// enum `entries`, array `element`, string-format `checks`/`format`), so snowform's
+// introspection must branch on the schema version at runtime.
+// =============================================================================
+
+describe('getZodFieldInfo with Zod 4 schemas', () => {
+  it('should detect string type', () => {
+    const info = getZodFieldInfo(z4.string());
+    expect(info.baseType).toBe('string');
+    expect(info.isOptional).toBe(false);
+    expect(info.isEmail).toBe(false);
+  });
+
+  it('should detect email validation (deprecated .email() form)', () => {
+    const info = getZodFieldInfo(z4.string().email());
+    expect(info.baseType).toBe('string');
+    expect(info.isEmail).toBe(true);
+  });
+
+  it('should detect email validation (top-level z.email() form)', () => {
+    const info = getZodFieldInfo(z4.email());
+    expect(info.baseType).toBe('string');
+    expect(info.isEmail).toBe(true);
+  });
+
+  it('should detect optional fields', () => {
+    const info = getZodFieldInfo(z4.string().optional());
+    expect(info.baseType).toBe('string');
+    expect(info.isOptional).toBe(true);
+  });
+
+  it('should detect nullable fields as optional', () => {
+    const info = getZodFieldInfo(z4.string().nullable());
+    expect(info.isOptional).toBe(true);
+  });
+
+  it('should detect number type', () => {
+    expect(getZodFieldInfo(z4.number()).baseType).toBe('number');
+  });
+
+  it('should detect boolean type', () => {
+    expect(getZodFieldInfo(z4.boolean()).baseType).toBe('boolean');
+  });
+
+  it('should detect enum type with values', () => {
+    const info = getZodFieldInfo(z4.enum(['active', 'inactive', 'pending']));
+    expect(info.baseType).toBe('enum');
+    expect(info.enumValues).toEqual(['active', 'inactive', 'pending']);
+  });
+
+  it('should detect date type', () => {
+    expect(getZodFieldInfo(z4.date()).baseType).toBe('date');
+  });
+
+  it('should detect array type with element info', () => {
+    const info = getZodFieldInfo(z4.array(z4.string()));
+    expect(info.baseType).toBe('array');
+    expect(info.arrayElementInfo?.baseType).toBe('string');
+  });
+
+  it('should unwrap schema with .default()', () => {
+    expect(getZodFieldInfo(z4.string().default('hello')).baseType).toBe('string');
+  });
+
+  it('should unwrap schema with .transform() (pipe)', () => {
+    expect(getZodFieldInfo(z4.string().transform(v => v.toUpperCase())).baseType).toBe('string');
+  });
+
+  it('should handle union with literal (optional URL pattern)', () => {
+    const info = getZodFieldInfo(z4.string().url().optional().or(z4.literal('')));
+    expect(info.baseType).toBe('string');
+    expect(info.isOptional).toBe(true);
+  });
+
+  it('should detect email on deeply wrapped schema', () => {
+    const info = getZodFieldInfo(z4.string().email().optional().nullable());
+    expect(info.baseType).toBe('string');
+    expect(info.isEmail).toBe(true);
+    expect(info.isOptional).toBe(true);
+  });
+});
+
+describe('getZodShape with Zod 4 schemas', () => {
+  it('should extract shape from a plain object', () => {
+    const shape = getZodShape(z4.object({ name: z4.string(), age: z4.number() }));
+    expect(Object.keys(shape).sort()).toEqual(['age', 'name']);
+  });
+
+  it('should extract shape from a refined object', () => {
+    const schema = z4
+      .object({ password: z4.string(), confirm: z4.string() })
+      .refine(d => d.password === d.confirm);
+    expect(Object.keys(getZodShape(schema)).sort()).toEqual(['confirm', 'password']);
+  });
+
+  it('should extract shape from a transformed (piped) object', () => {
+    const schema = z4.object({ a: z4.string(), b: z4.string() }).transform(v => v);
+    expect(Object.keys(getZodShape(schema)).sort()).toEqual(['a', 'b']);
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -244,12 +244,32 @@ export type SnowFormChildren<T extends FieldValues> = (helpers: SnowFormHelpers<
 // =============================================================================
 
 /**
- * A Zod object schema, possibly wrapped in ZodEffects (refine, superRefine, transform)
+ * Structural match for a Zod 4 schema. Zod 4 moved its output type to
+ * `_zod.output` (and removed the v3 `ZodEffects` wrapper); an object schema's
+ * output is itself an object. Matching structurally lets SnowForm accept Zod 4
+ * schemas without importing a specific Zod entrypoint.
+ */
+type ZodV4ObjectSchema = { readonly _zod: { readonly output: object } };
+
+/**
+ * A Zod object schema (Zod 3 or Zod 4), possibly wrapped in effects
+ * (refine, superRefine, transform).
  */
 export type ZodObjectOrEffects =
   | z.ZodObject<z.ZodRawShape>
   | z.ZodEffects<z.ZodObject<z.ZodRawShape>>
-  | z.ZodEffects<z.ZodEffects<z.ZodObject<z.ZodRawShape>>>;
+  | z.ZodEffects<z.ZodEffects<z.ZodObject<z.ZodRawShape>>>
+  | ZodV4ObjectSchema;
+
+/**
+ * Infer the form values type from a Zod schema, version-agnostically.
+ * Zod 4 stores its output type at `_zod.output`; Zod 3 at `_output`.
+ */
+export type InferZodValues<T> = T extends { _zod: { output: infer O } }
+  ? O
+  : T extends { _output: infer O }
+    ? O
+    : never;
 
 /**
  * Props for the SnowForm component
@@ -257,7 +277,11 @@ export type ZodObjectOrEffects =
  * @typeParam TSchema - The Zod schema type (supports refine/superRefine)
  * @typeParam TResponse - The response type from onSubmit
  */
-export interface SnowFormProps<TSchema extends ZodObjectOrEffects, TResponse = unknown> {
+export interface SnowFormProps<
+  TSchema extends ZodObjectOrEffects,
+  TResponse = unknown,
+  TValues extends FieldValues = InferZodValues<TSchema>,
+> {
   /** Zod schema defining the form structure */
   schema: TSchema;
 
@@ -265,13 +289,13 @@ export interface SnowFormProps<TSchema extends ZodObjectOrEffects, TResponse = u
   overrides?: Partial<Record<string, FieldConfig>>;
 
   /** Static default values */
-  defaultValues?: Partial<z.infer<TSchema>>;
+  defaultValues?: Partial<TValues>;
 
   /** Async function to fetch default values */
-  fetchDefaultValues?: () => Promise<Partial<z.infer<TSchema>>>;
+  fetchDefaultValues?: () => Promise<Partial<TValues>>;
 
   /** Submit handler - receives validated form values */
-  onSubmit?: (values: z.infer<TSchema>) => Promise<TResponse>;
+  onSubmit?: (values: TValues) => Promise<TResponse>;
 
   /** Called after successful submission */
   onSuccess?: (response: TResponse) => void;
@@ -289,7 +313,7 @@ export interface SnowFormProps<TSchema extends ZodObjectOrEffects, TResponse = u
   id?: string;
 
   /** Custom layout via render function */
-  children?: SnowFormChildren<z.infer<TSchema>>;
+  children?: SnowFormChildren<TValues>;
 }
 
 // =============================================================================

--- a/src/utils/zod.ts
+++ b/src/utils/zod.ts
@@ -1,10 +1,164 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import type { FieldValues, Resolver } from 'react-hook-form';
 import { z } from 'zod';
 
 import type { SchemaFieldInfo } from '../types';
 
 // =============================================================================
-// Zod Schema Analysis
+// Zod version detection
+// =============================================================================
+//
+// Zod 3 and Zod 4 expose completely different internals. Zod 3 stores its
+// definition under `_def` (with `instanceof` class checks and `_def.typeName`),
+// while Zod 4 moved everything under `_zod.def` with a string `type` discriminator
+// and removed the `ZodEffects` wrapper. snowform introspects schemas to detect
+// field types, so it must branch on the schema version at runtime. This keeps the
+// package working for consumers on either major (e.g. apps mid-migration).
+
+/** Minimal structural view of a Zod 4 schema's internal definition. */
+interface V4Check {
+  _zod?: { def?: { format?: string } };
+}
+interface V4Def {
+  type: string;
+  innerType?: V4Schema; // optional / nullable / default wrappers
+  element?: V4Schema; // array element
+  options?: V4Schema[]; // union members
+  shape?: Record<string, V4Schema>; // object fields
+  entries?: Record<string, unknown>; // enum values
+  format?: string; // string format (e.g. 'email')
+  checks?: V4Check[]; // string-format checks (deprecated `.email()` form)
+  in?: V4Schema; // pipe input side (transform)
+}
+interface V4Schema {
+  _zod: { def: V4Def };
+}
+
+function isV4Schema(schema: unknown): schema is V4Schema {
+  return typeof schema === 'object' && schema !== null && '_zod' in schema;
+}
+
+// =============================================================================
+// Zod 4 introspection (structural — reads `_zod.def`)
+// =============================================================================
+
+function v4Def(schema: V4Schema): V4Def {
+  return schema._zod.def;
+}
+
+/**
+ * Unwrap a Zod 4 schema to its underlying type: peels optional/nullable/default
+ * wrappers and transform pipes, then resolves the main member of a union.
+ */
+function v4Unwrap(schema: V4Schema): V4Schema {
+  let current = schema;
+
+  for (;;) {
+    const def = v4Def(current);
+    if ((def.type === 'optional' || def.type === 'nullable' || def.type === 'default') && def.innerType) {
+      current = def.innerType;
+    } else if (def.type === 'pipe' && def.in) {
+      // `.transform()` produces a pipe; the source schema is the input side.
+      current = def.in;
+    } else {
+      break;
+    }
+  }
+
+  // Union - find the main type (not a literal), e.g. z.string().optional().or(z.literal(''))
+  const def = v4Def(current);
+  if (def.type === 'union' && def.options) {
+    for (const option of def.options) {
+      const unwrapped = v4Unwrap(option);
+      if (v4Def(unwrapped).type !== 'literal') {
+        return unwrapped;
+      }
+    }
+  }
+
+  return current;
+}
+
+function v4IsOptional(schema: V4Schema): boolean {
+  const def = v4Def(schema);
+  if (def.type === 'optional' || def.type === 'nullable') return true;
+
+  if (def.type === 'union' && def.options) {
+    for (const option of def.options) {
+      if (v4Def(option).type === 'literal') return true;
+      if (v4IsOptional(option)) return true;
+    }
+  }
+
+  return false;
+}
+
+function v4IsEmail(def: V4Def): boolean {
+  // Top-level z.email() stores the format on the schema; the deprecated
+  // z.string().email() form stores it inside a string-format check.
+  if (def.format === 'email') return true;
+  return def.checks?.some(check => check._zod?.def?.format === 'email') ?? false;
+}
+
+function getV4Shape(schema: V4Schema): Record<string, V4Schema> {
+  let current = schema;
+  // Unwrap transform pipes to reach the object (refine keeps the `object` type).
+  while (v4Def(current).type === 'pipe' && v4Def(current).in) {
+    current = v4Def(current).in as V4Schema;
+  }
+
+  const def = v4Def(current);
+  if (def.type !== 'object' || !def.shape) {
+    console.error('[SnowForm] Schema must be a ZodObject (after unwrapping effects)');
+    return {};
+  }
+  return def.shape;
+}
+
+function getV4FieldInfo(field: V4Schema): SchemaFieldInfo {
+  const unwrapped = v4Unwrap(field);
+  const def = v4Def(unwrapped);
+
+  let baseType: SchemaFieldInfo['baseType'] = 'unknown';
+  let enumValues: string[] | undefined;
+  let isEmail = false;
+  let arrayElementInfo: SchemaFieldInfo | undefined;
+
+  switch (def.type) {
+    case 'string':
+      baseType = 'string';
+      isEmail = v4IsEmail(def);
+      break;
+    case 'number':
+      baseType = 'number';
+      break;
+    case 'boolean':
+      baseType = 'boolean';
+      break;
+    case 'enum':
+      baseType = 'enum';
+      enumValues = def.entries ? (Object.values(def.entries) as string[]) : undefined;
+      break;
+    case 'date':
+      baseType = 'date';
+      break;
+    case 'array':
+      baseType = 'array';
+      if (def.element) arrayElementInfo = getV4FieldInfo(def.element);
+      break;
+  }
+
+  return {
+    baseType,
+    isOptional: v4IsOptional(field),
+    isEmail,
+    enumValues,
+    arrayElementInfo,
+  };
+}
+
+// =============================================================================
+// Zod 3 introspection (reads `_def`, uses `instanceof`)
 // =============================================================================
 
 /**
@@ -74,15 +228,7 @@ function isEmailString(schema: z.ZodString): boolean {
   return schema._def.checks?.some((check: { kind: string }) => check.kind === 'email') ?? false;
 }
 
-// =============================================================================
-// Public API
-// =============================================================================
-
-/**
- * Extract the shape (fields) from a Zod schema
- * Supports schemas wrapped in ZodEffects (refine, superRefine, transform)
- */
-export function getZodShape(schema: z.ZodTypeAny): Record<string, z.ZodTypeAny> {
+function getV3Shape(schema: z.ZodTypeAny): Record<string, z.ZodTypeAny> {
   try {
     // Unwrap ZodEffects (refine, superRefine, transform, etc.)
     let current: z.ZodTypeAny = schema;
@@ -108,10 +254,7 @@ export function getZodShape(schema: z.ZodTypeAny): Record<string, z.ZodTypeAny> 
   }
 }
 
-/**
- * Get information about a specific Zod field
- */
-export function getZodFieldInfo(field: z.ZodTypeAny): SchemaFieldInfo {
+function getV3FieldInfo(field: z.ZodTypeAny): SchemaFieldInfo {
   const unwrapped = unwrapSchema(field);
 
   // Detect base type
@@ -135,7 +278,7 @@ export function getZodFieldInfo(field: z.ZodTypeAny): SchemaFieldInfo {
   } else if (unwrapped instanceof z.ZodArray) {
     baseType = 'array';
     // Extract element type info recursively
-    arrayElementInfo = getZodFieldInfo(unwrapped._def.type);
+    arrayElementInfo = getV3FieldInfo(unwrapped._def.type);
   }
 
   return {
@@ -147,10 +290,36 @@ export function getZodFieldInfo(field: z.ZodTypeAny): SchemaFieldInfo {
   };
 }
 
+// =============================================================================
+// Public API (version-agnostic)
+// =============================================================================
+
 /**
- * Create a resolver for react-hook-form from a Zod schema
- * Supports schemas with refine/superRefine (ZodEffects)
+ * Extract the shape (fields) from a Zod schema (Zod 3 or Zod 4).
+ * Supports schemas wrapped in effects (refine, superRefine, transform).
  */
-export function createZodResolver(schema: z.ZodTypeAny) {
-  return zodResolver(schema);
+export function getZodShape(schema: unknown): Record<string, z.ZodTypeAny> {
+  if (isV4Schema(schema)) {
+    return getV4Shape(schema) as unknown as Record<string, z.ZodTypeAny>;
+  }
+  return getV3Shape(schema as z.ZodTypeAny);
+}
+
+/**
+ * Get information about a specific Zod field (Zod 3 or Zod 4).
+ */
+export function getZodFieldInfo(field: unknown): SchemaFieldInfo {
+  if (isV4Schema(field)) {
+    return getV4FieldInfo(field);
+  }
+  return getV3FieldInfo(field as z.ZodTypeAny);
+}
+
+/**
+ * Create a resolver for react-hook-form from a Zod schema (Zod 3 or Zod 4).
+ * Supports schemas with refine/superRefine. @hookform/resolvers v5's zodResolver
+ * accepts both major versions at runtime; the cast bridges the static types.
+ */
+export function createZodResolver<T extends FieldValues = FieldValues>(schema: unknown): Resolver<T> {
+  return zodResolver(schema as Parameters<typeof zodResolver>[0]) as unknown as Resolver<T>;
 }


### PR DESCRIPTION
snowform introspected Zod 3 internals (`_def`, `instanceof`, `ZodEffects`), so Zod 4 schemas silently rendered empty forms. This adds runtime version detection (`'_zod' in schema`) with a structural Zod 4 introspection path while keeping the Zod 3 path verbatim — fully non-breaking for apps still on v3. It also broadens the `SnowFormProps`/`SnowForm` generic to accept v4 object schemas and infer form values version-agnostically (new `InferZodValues` type + `TValues` param). Includes Zod 4 introspection tests, a type-level test asserting v4 acceptance/inference, and a v3-vs-v4 render/validation benchmark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compatibilité étendue avec Zod 4, tout en conservant le support de Zod 3.
  * Typage des formulaires amélioré pour mieux refléter les valeurs réellement soumises.

* **Bug Fixes**
  * Meilleure détection de plusieurs types de champs et de contraintes dans les schémas.
  * Les valeurs par défaut, la validation et la soumission sont désormais plus cohérentes avec les formulaires complexes.

* **Tests**
  * Ajout de vérifications de compatibilité et de performances pour les formulaires et les schémas Zod 3/4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->