### PR TITLE
fix: partial defaultValues no longer narrows the inferred values type

### DIFF
--- a/src/SnowForm.tsx
+++ b/src/SnowForm.tsx
@@ -116,7 +116,9 @@ export function SnowForm<
   // ==========================================================================
 
   const computedDefaultValues = useMemo(
-    () => initializeDefaultValues<FormValues>(schemaShape, providedDefaultValues, overrides ?? {}),
+    // `defaultValues` is typed on the schema (`InferZodValues<TSchema>`) to avoid
+    // narrowing `TValues`; it equals `FormValues` unless a caller overrides TValues.
+    () => initializeDefaultValues<FormValues>(schemaShape, providedDefaultValues as Partial<FormValues>, overrides ?? {}),
     [schemaShape, providedDefaultValues, overrides]
   );
 

--- a/src/__tests__/types-v4.test-d.tsx
+++ b/src/__tests__/types-v4.test-d.tsx
@@ -65,3 +65,52 @@ const _pref: SnowFormProps<typeof v4refined> = {
   },
 };
 void _pref;
+
+// --- Regression: a PARTIAL defaultValues must NOT narrow the values type ---
+// (defaultValues={{ token }} previously inferred TValues = { token }, dropping `password`.)
+const partial = z.object({ token: z.string(), password: z.string() });
+
+const _pPartial: SnowFormProps<typeof partial> = {
+  schema: partial,
+  defaultValues: { token: 'x' }, // only one of two keys
+  onSubmit: async values => {
+    const t: string = values.token;
+    const p: string = values.password; // must still exist despite partial defaultValues
+    void t;
+    void p;
+  },
+};
+void _pPartial;
+
+// same via the actual component (the reported repro)
+const _elPartial = (
+  <SnowForm
+    schema={partial}
+    defaultValues={{ token: 'x' }}
+    onSubmit={async values => {
+      const p: string = values.password;
+      void p;
+    }}
+  />
+);
+void _elPartial;
+
+// a partial fetchDefaultValues must not narrow either
+const _pFetch: SnowFormProps<typeof partial> = {
+  schema: partial,
+  fetchDefaultValues: async () => ({ token: 'x' }),
+  onSubmit: async values => {
+    const p: string = values.password;
+    void p;
+  },
+};
+void _pFetch;
+
+// defaultValues must still be type-checked against the schema (unknown key rejected)
+const _pBadKey: SnowFormProps<typeof partial> = {
+  schema: partial,
+  // @ts-expect-error `nope` is not a field of the schema
+  defaultValues: { nope: 'x' },
+  onSubmit: async () => {},
+};
+void _pBadKey;

--- a/src/types.ts
+++ b/src/types.ts
@@ -288,11 +288,13 @@ export interface SnowFormProps<
   /** Field customizations - uses permissive FieldConfig for flexibility */
   overrides?: Partial<Record<string, FieldConfig>>;
 
-  /** Static default values */
-  defaultValues?: Partial<TValues>;
+  /**
+   * Static default values.
+   */
+  defaultValues?: Partial<InferZodValues<TSchema>>;
 
-  /** Async function to fetch default values */
-  fetchDefaultValues?: () => Promise<Partial<TValues>>;
+  /** Async function to fetch default values*/
+  fetchDefaultValues?: () => Promise<Partial<InferZodValues<TSchema>>>;
 
   /** Submit handler - receives validated form values */
   onSubmit?: (values: TValues) => Promise<TResponse>;


### PR DESCRIPTION
1.6.0 made the `TValues` generic inferable at `defaultValues?: Partial<TValues>`, so a partial `defaultValues` (e.g. `{ token }`) re-inferred `TValues` to only the provided keys and dropped the rest from `onSubmit` values — breaking any form that pre-fills defaults partially. This anchors `defaultValues` and `fetchDefaultValues` on `InferZodValues<TSchema>` (the schema-derived type) so those sites can no longer re-infer `TValues`, while `defaultValues` stays type-checked against the schema. The fix uses only `infer` (no `NoInfer` intrinsic), so it works on any TypeScript version. Adds type-level regression tests for partial `defaultValues`, partial `fetchDefaultValues`, and the component-level repro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)